### PR TITLE
Set the Main object as a global Window Object and fixed the API endpoint

### DIFF
--- a/WebpackMVC5App/Scripts/App.ts
+++ b/WebpackMVC5App/Scripts/App.ts
@@ -12,9 +12,12 @@ import "../Content/Site.scss";
 import Main from './main';
 
 declare global {
-    interface Window { RandomWebConfigValue: string; UrlPrefix: string;  }
+    interface Window {
+        RandomWebConfigValue: string;
+        UrlPrefix: string;
+        Main: any
+    }
 }
-
-const mn = new Main(window.RandomWebConfigValue, window.UrlPrefix);
-mn.TestFunc();
+window.Main = new Main(window.RandomWebConfigValue, window.UrlPrefix);
+window.Main.TestFunc();
 

--- a/WebpackMVC5App/Views/Home/Kendo.cshtml
+++ b/WebpackMVC5App/Views/Home/Kendo.cshtml
@@ -11,6 +11,6 @@
 
 @section footer {
     <script>
-        mn.LoadKendoGrid();
+        window.Main.LoadKendoGrid();
     </script>
 }

--- a/WebpackMVC5App/Views/Shared/_Layout.cshtml
+++ b/WebpackMVC5App/Views/Shared/_Layout.cshtml
@@ -6,7 +6,7 @@
     <title>@ViewBag.Title - My ASP.NET Application</title>
     <script>
         window.RandomWebConfigValue = '@WebpackMVC5App.Helpers.WebConfigSettings.RandomWebConfigValue';
-        window.UrlPrefix = 'http://@Request.Url.Host@Request.Url.AbsolutePath';
+        window.UrlPrefix = window.location.origin + '/' + window.location.pathname.split('/')[1] + '/';
     </script>
     @RenderSection("header", required: false)
     @if (System.Web.HttpContext.Current.IsDebuggingEnabled)


### PR DESCRIPTION
This allows the `/home/kendo` route to have access the Main. 